### PR TITLE
feat(movies): configure create endpoint

### DIFF
--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply('hello world');
+      }
+    }
+  }]);  
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -10,7 +10,7 @@ exports.register = (server, options, next) => {
         reply('hello world');
       }
     }
-  }]);  
+  }]);
 
   next();
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,4 +12,14 @@ const server = new Hapi.Server({
 
 server.connection({ port: Config.PORT });
 
+server.register([
+  require('hapi-bookshelf-serializer'),
+  require('./plugins/features/movies')
+], (err) => {
+  /* istanbul ignore if */
+  if (err) {
+    throw err;
+  }
+});
+
 module.exports = server;


### PR DESCRIPTION
Why: We need a way to add movies to the database

What: creates an endpoint at `/movies` that accepts POST requests for record creation

Details: doesn't do much just yet.